### PR TITLE
[codex] harden api-doc-crafter entrypoint

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -10,7 +10,7 @@
     <packaging>jar</packaging>
 
     <name>api-doc-crafter</name>
-    <url>https://github.com/YunaBraska/type-map</url>
+    <url>https://github.com/YunaBraska/api-doc-crafter</url>
 
     <scm>
         <connection>scm:git:ssh://git@github.com/YunaBraska/api-doc-crafter.git</connection>

--- a/src/main/java/berlin/yuna/apidoccrafter/App.java
+++ b/src/main/java/berlin/yuna/apidoccrafter/App.java
@@ -47,7 +47,16 @@ import static java.util.Optional.ofNullable;
 public class App {
 
     public static void main(final String[] args) {
-        config().putAll(readConfigs()); // can't be done in static block because native executable will freeze it
+        config().clear();
+        if (isSimpleHelpArg(args)) {
+            printUsage();
+            return;
+        }
+        config().putAll(readConfigs(args)); // can't be done in static block because native executable will freeze it
+        if (config().asBooleanOpt("help").orElse(false) || config().asBooleanOpt("h").orElse(false)) {
+            printUsage();
+            return;
+        }
         final Path inputDir = parseWorkDir(config().asString(WORK_DIR));
         final Path outputDir = parseOutputDir(config().asString(OUTPUT_DIR), inputDir);
         final String fileIncludes = config().asString(FILE_INCLUDES);
@@ -75,6 +84,35 @@ public class App {
 
         // TODO: find non resolvable components in other API files and merge these references
         HtmlGenerator.generateHtml(sortByString(mergedApis, pathOpenAPIEntry -> displayName(pathOpenAPIEntry.getKey(), pathOpenAPIEntry.getValue())), outputDir);
+    }
+
+    private static boolean isSimpleHelpArg(final String[] args) {
+        return args != null && Stream.of(args)
+            .filter(Objects::nonNull)
+            .map(String::trim)
+            .anyMatch(arg -> "-h".equals(arg) || "--help".equals(arg));
+    }
+
+    private static void printUsage() {
+        System.out.println("""
+            api-doc-crafter
+
+            Usage:
+              java -jar api-doc-crafter.jar --adc_work_dir="<input-dir>" --adc_output_dir="<output-dir>"
+              api-doc-crafter --adc_work_dir="<input-dir>" --adc_file_includes="**/*.yaml"
+
+            Common options:
+              -h, --help                      Show this help message
+              --adc_work_dir <path>           Directory containing OpenAPI files
+              --adc_output_dir <path>         Directory for generated HTML, JSON, YAML, and static assets
+              --adc_file_includes <glob>      Include files by glob, separated by :: or |
+              --adc_file_excludes <glob>      Exclude files by glob, separated by :: or |
+              --adc_max_deep <number>         Maximum directory depth to scan
+              --adc_enable_object_mapper      Enable extra Jackson parsing fallback
+              --adc_enable_custom_info        Override OpenAPI info/contact/license/server/tag metadata
+
+            Non-GitHub Action usage keeps the adc_ prefix used by action inputs.
+            """);
     }
 
     private static void downloadRemoteOpenApiFiles(final Path inputDir, final int maxDeep) {

--- a/src/main/java/berlin/yuna/apidoccrafter/logic/Processor.java
+++ b/src/main/java/berlin/yuna/apidoccrafter/logic/Processor.java
@@ -187,7 +187,6 @@ public class Processor {
                 !enableObjectMapper ? null : parseWith("Json." + safeJsonMapper.getClass().getSimpleName(), p -> safeJsonMapper.readValue(Files.readString(p), OpenAPI.class), filePath),
                 !enableObjectMapper ? null : parseWith("Yaml." + safeYamlMapper.getClass().getSimpleName(), p -> safeYamlMapper.readValue(Files.readString(p), OpenAPI.class), filePath)
             )
-            .parallel()
             .filter(Objects::nonNull)
             .filter(pr -> pr.api() != null && pr.jsonSize() > 20) // 20 == empty OpenAPI file
             .max(Comparator.comparingInt(ParseResult::jsonSize))

--- a/src/test/java/berlin/yuna/apidoccrafter/AppEntrypointTest.java
+++ b/src/test/java/berlin/yuna/apidoccrafter/AppEntrypointTest.java
@@ -1,0 +1,158 @@
+package berlin.yuna.apidoccrafter;
+
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.io.TempDir;
+
+import java.io.ByteArrayOutputStream;
+import java.io.IOException;
+import java.io.PrintStream;
+import java.nio.charset.StandardCharsets;
+import java.nio.file.Files;
+import java.nio.file.Path;
+
+import static berlin.yuna.apidoccrafter.config.Config.FILE_INCLUDES;
+import static berlin.yuna.apidoccrafter.config.Config.MAX_DEEP;
+import static berlin.yuna.apidoccrafter.config.Config.OUTPUT_DIR;
+import static berlin.yuna.apidoccrafter.config.Config.WORK_DIR;
+import static berlin.yuna.apidoccrafter.config.Config.config;
+import static org.assertj.core.api.Assertions.assertThat;
+
+class AppEntrypointTest {
+
+    @TempDir
+    Path tempDir;
+
+    @BeforeEach
+    void resetConfigBeforeTest() {
+        resetConfig();
+    }
+
+    @AfterEach
+    void resetConfigAfterTest() {
+        resetConfig();
+    }
+
+    private static void resetConfig() {
+        config().clear();
+        System.getProperties().keySet().stream()
+            .map(Object::toString)
+            .filter(key -> key.toLowerCase().startsWith("adc_"))
+            .toList()
+            .forEach(System.getProperties()::remove);
+    }
+
+    @Test
+    void shouldPrintHelpFromLongOption() throws Exception {
+        final String output = captureStdout(() -> App.main(new String[]{"--help"}));
+
+        assertThat(output)
+            .contains("Usage:")
+            .contains("api-doc-crafter")
+            .contains("--adc_work_dir")
+            .contains("--adc_output_dir");
+    }
+
+    @Test
+    void shouldPrintHelpFromShortOption() throws Exception {
+        final String output = captureStdout(() -> App.main(new String[]{"-h"}));
+
+        assertThat(output)
+            .contains("Usage:")
+            .contains("api-doc-crafter");
+    }
+
+    @Test
+    void shouldUseRuntimeArgumentsForWorkAndOutputDirectories() throws IOException {
+        final Path input = tempDir.resolve("input");
+        final Path output = tempDir.resolve("output");
+        writeOpenApi(input.resolve("smoke.json"), "Smoke API");
+
+        App.main(new String[]{
+            arg(WORK_DIR, input),
+            arg(OUTPUT_DIR, output),
+            arg(FILE_INCLUDES, "**/smoke.json"),
+            arg(MAX_DEEP, "1")
+        });
+
+        assertThat(output.resolve("index.html")).exists();
+        assertThat(output.resolve("smoke_api.html")).exists();
+        assertThat(output.resolve("smoke_api.yaml")).exists();
+        assertThat(output.resolve("smoke_api.json")).content().contains("\"title\" : \"Smoke API\"");
+    }
+
+    @Test
+    void shouldNotReuseRuntimeArgumentsBetweenEntrypointRuns() throws IOException {
+        final Path firstInput = tempDir.resolve("first-input");
+        final Path firstOutput = tempDir.resolve("first-output");
+        final Path secondInput = tempDir.resolve("second-input");
+        final Path defaultSecondOutput = tempDir.resolve("swagger_output");
+        writeOpenApi(firstInput.resolve("first.json"), "First API");
+        writeOpenApi(secondInput.resolve("second.json"), "Second API");
+
+        App.main(new String[]{
+            arg(WORK_DIR, firstInput),
+            arg(OUTPUT_DIR, firstOutput),
+            arg(FILE_INCLUDES, "**/first.json"),
+            arg(MAX_DEEP, "1")
+        });
+        App.main(new String[]{
+            arg(WORK_DIR, secondInput),
+            arg(FILE_INCLUDES, "**/second.json"),
+            arg(MAX_DEEP, "1")
+        });
+
+        assertThat(firstOutput.resolve("first_api.json")).exists();
+        assertThat(defaultSecondOutput.resolve("second_api.json")).exists();
+        assertThat(firstOutput.resolve("second_api.json")).doesNotExist();
+    }
+
+    private static String arg(final String key, final Path value) {
+        return arg(key, value.toString());
+    }
+
+    private static String arg(final String key, final String value) {
+        return "--" + key + "=\"" + value + "\"";
+    }
+
+    private static String captureStdout(final ThrowingAction action) throws Exception {
+        final PrintStream originalOut = System.out;
+        final ByteArrayOutputStream output = new ByteArrayOutputStream();
+        try (PrintStream printStream = new PrintStream(output, true, StandardCharsets.UTF_8)) {
+            System.setOut(printStream);
+            action.run();
+        } finally {
+            System.setOut(originalOut);
+        }
+        return output.toString(StandardCharsets.UTF_8);
+    }
+
+    private static void writeOpenApi(final Path file, final String title) throws IOException {
+        Files.createDirectories(file.getParent());
+        Files.writeString(file, """
+            {
+              "openapi": "3.0.0",
+              "info": {
+                "title": "%s",
+                "version": "1.0.0"
+              },
+              "paths": {
+                "/health": {
+                  "get": {
+                    "responses": {
+                      "200": {
+                        "description": "OK"
+                      }
+                    }
+                  }
+                }
+              }
+            }
+            """.formatted(title));
+    }
+
+    private interface ThrowingAction {
+        void run() throws Exception;
+    }
+}

--- a/src/test/java/berlin/yuna/apidoccrafter/logic/AppTest.java
+++ b/src/test/java/berlin/yuna/apidoccrafter/logic/AppTest.java
@@ -1,6 +1,8 @@
 package berlin.yuna.apidoccrafter.logic;
 
 import berlin.yuna.apidoccrafter.App;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 
 import java.io.IOException;
@@ -9,9 +11,21 @@ import java.nio.file.Path;
 import java.util.List;
 
 import static berlin.yuna.apidoccrafter.config.Config.*;
+import static berlin.yuna.apidoccrafter.util.Util.safeJsonMapper;
+import static berlin.yuna.apidoccrafter.util.Util.safeYamlMapper;
 import static org.assertj.core.api.Assertions.assertThat;
 
 class AppTest {
+
+    @BeforeEach
+    void resetConfigBeforeTest() {
+        resetConfig();
+    }
+
+    @AfterEach
+    void resetConfigAfterTest() {
+        resetConfig();
+    }
 
     @Test
     void runApp() {
@@ -23,11 +37,11 @@ class AppTest {
         System.getProperties().put(REMOVE_PATTERNS, "Management|**Internal**");
         System.getProperties().put(SWAGGER_LOGO, "https://static1.smartbear.co/swagger/media/assets/images/swagger_logo.svg");
         System.getProperties().put(SWAGGER_LOGO_LINK, "index.html");
-        System.getProperties().put(SORT_TAGS, false);
+        System.setProperty(SORT_TAGS, "false");
         System.getProperties().put(FILE_INCLUDES, "**/files/**||**/api-doc-download/**");
         System.getProperties().put(OUTPUT_DIR, swaggerOutput.toString());
-        System.getProperties().put(ENABLE_CUSTOM_INFO, false);
-        System.getProperties().put(ENABLE_OBJECT_MAPPER, true);
+        System.setProperty(ENABLE_CUSTOM_INFO, "false");
+        System.setProperty(ENABLE_OBJECT_MAPPER, "true");
 
         App.main(new String[0]);
 
@@ -56,15 +70,7 @@ class AppTest {
             assertThat(swaggerOutput.resolve(fileName)).exists();
             assertThat(expectedFilesPath.resolve(fileName)).exists();
 
-            try {
-                assertThat(Files.readString(swaggerOutput.resolve(fileName)).trim()).isEqualTo(Files.readString(expectedFilesPath.resolve(fileName)).trim());
-            } catch (IOException e) {
-                try {
-                    assertThat(Files.readAllBytes(swaggerOutput.resolve(fileName))).isEqualTo(Files.readAllBytes(expectedFilesPath.resolve(fileName)));
-                } catch (IOException ex) {
-                    throw new IllegalArgumentException(ex);
-                }
-            }
+            assertGeneratedFileEquals(swaggerOutput.resolve(fileName), expectedFilesPath.resolve(fileName));
         });
     }
 
@@ -77,13 +83,13 @@ class AppTest {
         System.getProperties().put(REMOVE_PATTERNS, "Management|**Internal**");
         System.getProperties().put(SWAGGER_LOGO, "https://static1.smartbear.co/swagger/media/assets/images/swagger_logo.svg");
         System.getProperties().put(SWAGGER_LOGO_LINK, "index.html");
-        System.getProperties().put(SORT_TAGS, false);
+        System.setProperty(SORT_TAGS, "false");
         System.getProperties().put(FILE_INCLUDES, "**/files/**||**/api-doc-download/**");
         System.getProperties().put(OUTPUT_DIR, swaggerOutput.toString());
-        System.getProperties().put(ENABLE_OBJECT_MAPPER, true);
+        System.setProperty(ENABLE_OBJECT_MAPPER, "true");
 
         // Activate metadata enrichment
-        System.getProperties().put(ENABLE_CUSTOM_INFO, true);
+        System.setProperty(ENABLE_CUSTOM_INFO, "true");
         System.getProperties().put(CONFIG_PREFIX + "info_title", "Custom Title");
         System.getProperties().put(CONFIG_PREFIX + "info_version", "9.9.9");
         System.getProperties().put(CONFIG_PREFIX + "info_summary", "Custom Summary");
@@ -127,5 +133,65 @@ class AppTest {
             .contains("\"description\" : \"EE\"")
             .contains("\"name\" : \"FF\"");
 
+    }
+
+    private static void assertGeneratedFileEquals(final Path actual, final Path expected) {
+        try {
+            if (actual.toString().endsWith(".json")) {
+                assertThat(safeJsonMapper.readTree(actual.toFile())).isEqualTo(safeJsonMapper.readTree(expected.toFile()));
+            } else if (actual.toString().endsWith(".yaml") || actual.toString().endsWith(".yml")) {
+                assertThat(safeYamlMapper.readTree(actual.toFile())).isEqualTo(safeYamlMapper.readTree(expected.toFile()));
+            } else if (actual.toString().endsWith(".html") && Files.readString(actual).contains("      spec: ")) {
+                assertHtmlWithEmbeddedSpecEquals(Files.readString(actual).trim(), Files.readString(expected).trim());
+            } else {
+                assertThat(Files.readString(actual).trim()).isEqualTo(Files.readString(expected).trim());
+            }
+        } catch (IOException e) {
+            try {
+                assertThat(Files.readAllBytes(actual)).isEqualTo(Files.readAllBytes(expected));
+            } catch (IOException ex) {
+                throw new IllegalArgumentException(ex);
+            }
+        }
+    }
+
+    private static void assertHtmlWithEmbeddedSpecEquals(final String actual, final String expected) throws IOException {
+        final String specPrefix = "      spec: ";
+        final List<String> actualLines = actual.lines().toList();
+        final List<String> expectedLines = expected.lines().toList();
+        final int actualSpecLine = specLineIndex(actualLines, specPrefix);
+        final int expectedSpecLine = specLineIndex(expectedLines, specPrefix);
+
+        assertThat(actualSpecLine).isGreaterThanOrEqualTo(0);
+        assertThat(expectedSpecLine).isGreaterThanOrEqualTo(0);
+        assertThat(safeJsonMapper.readTree(specPayload(actualLines.get(actualSpecLine), specPrefix)))
+            .isEqualTo(safeJsonMapper.readTree(specPayload(expectedLines.get(expectedSpecLine), specPrefix)));
+
+        final String normalizedActual = actual.replace(actualLines.get(actualSpecLine), specPrefix + "<openapi-spec>,");
+        final String normalizedExpected = expected.replace(expectedLines.get(expectedSpecLine), specPrefix + "<openapi-spec>,");
+        assertThat(normalizedActual).isEqualTo(normalizedExpected);
+    }
+
+    private static int specLineIndex(final List<String> lines, final String specPrefix) {
+        for (int index = 0; index < lines.size(); index++) {
+            if (lines.get(index).startsWith(specPrefix))
+                return index;
+        }
+        return -1;
+    }
+
+    private static String specPayload(final String line, final String specPrefix) {
+        final String result = line.substring(specPrefix.length()).trim();
+        return result.endsWith(",") ? result.substring(0, result.length() - 1) : result;
+    }
+
+    private static void resetConfig() {
+        config().clear();
+        System.getProperties().keySet().stream()
+            .map(Object::toString)
+            .filter(key -> key.toLowerCase().startsWith(CONFIG_PREFIX))
+            .toList()
+            .forEach(System.getProperties()::remove);
+        System.getProperties().remove("TEST_KEY");
     }
 }


### PR DESCRIPTION
## Summary
- wire CLI runtime args into App.main and add -h/--help output
- clear static config between runs so repeated JVM/native invocations do not reuse stale adc_* values
- remove parser stream parallelism for deterministic native-friendly parsing
- harden entrypoint tests for args, help, repeated runs, and generated OpenAPI comparison
- fix stale project URL in pom.xml

## Verification
- ./mvnw -B test
- ./mvnw -B -q test
- ./mvnw -B -q -DskipTests package
- git diff --check
- rg -n "\.parallel\(|parallelStream\(" src/main/java src/test/java

## Missing-feature / hardening follow-up plan
- Add public-entrypoint tests for empty input dirs, invalid work/output dirs, include/exclude glob conflicts, max-depth boundaries, malformed specs, duplicate titles, remote download failures, custom info precedence, server/tag grouping, and repeated/concurrent CLI invocations.
- Add native executable smoke coverage for Linux/macOS/Windows that runs --help and a tiny OpenAPI generation fixture after native-image builds.
- Replace static mutable config with an immutable per-run config object and return explicit run results instead of relying on process-global state.
- Treat invalid input/output paths as deterministic non-zero CLI failures once an exit-code boundary is introduced.
- Add golden semantic assertions around generated navigation and source links, not just generated OpenAPI payloads.
