### PR TITLE
ci: use native ARM runners

### DIFF
--- a/.github/workflows/build-merge.yml
+++ b/.github/workflows/build-merge.yml
@@ -43,7 +43,7 @@ jobs:
     if: ${{ always() && !cancelled() && needs.release.result == 'success' }}
     permissions:
       contents: read
-    uses: YunaBraska/YunaBraska/.github/workflows/wc_java_build_native.yml@f6c362d9c539d7a028b816572d812e892072c50b
+    uses: YunaBraska/YunaBraska/.github/workflows/wc_java_build_native.yml@44e7a7b0a933c8adc6e2f14732a3018a863edd4c
     with:
       ref: ${{ needs.release.outputs.commit_sha }}
       version: ${{ needs.release.outputs.version }}

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -42,7 +42,7 @@ jobs:
     if: ${{ always() && !cancelled() && needs.release.result == 'success' }}
     permissions:
       contents: read
-    uses: YunaBraska/YunaBraska/.github/workflows/wc_java_build_native.yml@f6c362d9c539d7a028b816572d812e892072c50b
+    uses: YunaBraska/YunaBraska/.github/workflows/wc_java_build_native.yml@44e7a7b0a933c8adc6e2f14732a3018a863edd4c
     with:
       ref: ${{ needs.release.outputs.commit_sha }}
       version: ${{ needs.release.outputs.version }}


### PR DESCRIPTION
Use the five-target native matrix: Linux AMD64/ARM64, macOS Intel/Apple Silicon, and Windows x64.